### PR TITLE
User must be logged in to access walls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-gem "devise", "~> 4.7"
+gem 'devise', '~> 4.7'
 
-gem "pry", "~> 0.12.2"
+gem 'pry', '~> 0.12.2'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :authenticate_user!
 
-  def after_sign_in_path_for(resource)
+  def after_sign_in_path_for(_resource)
     "/#{current_user.id}"
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def home; end
 end

--- a/app/controllers/walls_controller.rb
+++ b/app/controllers/walls_controller.rb
@@ -1,18 +1,15 @@
 class WallsController < ApplicationController
-
   def show
     session[:wall_id] = params[:id]
     @user = User.find_by(id: params[:id])
-    if Wall.find_by(id: params[:id]) == nil
-      Wall.create(id: params[:id])
-    end
+    Wall.create(id: params[:id]) if Wall.find_by(id: params[:id]).nil?
     @wall = Wall.find_by(id: params[:id])
 
-    if Post.find_by(wall_id: session[:wall_id]) == nil
-      @posts = []
-    else
-      @posts = Post.where(wall_id: session[:wall_id])
-    end
+    @posts = if Post.find_by(wall_id: session[:wall_id]).nil?
+               []
+             else
+               Post.where(wall_id: session[:wall_id])
+             end
     # @posts = Wall.find_by(id: current_user.id)
   end
 
@@ -29,5 +26,4 @@ class WallsController < ApplicationController
   def post_params
     params.require(:post).permit(:message)
   end
-
 end

--- a/app/lib/custom_authenticate_user_app.rb
+++ b/app/lib/custom_authenticate_user_app.rb
@@ -1,0 +1,5 @@
+class CustomAuthenticateUserApp < Devise::FailureApp
+  def route(_scope)
+    :unauthenticated_root
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -276,7 +276,11 @@ Devise.setup do |config|
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
-  #
+
+  config.warden do |manager|
+    manager.failure_app = CustomAuthenticateUserApp
+  end
+
   # config.warden do |manager|
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,17 @@
 Rails.application.routes.draw do
   get 'pages/home'
 
-
   devise_for :users
   resources :posts
 
   get '/:id', to: 'walls#show', as: 'wall'
   post '/walls', to: 'walls#create'
-  
+
   unauthenticated :user do
     root 'pages#home', as: :unauthenticated_root
   end
 
   authenticated :user do
-    root "posts#index", as: :authenticated_root
+    root 'posts#index', as: :authenticated_root
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe PostsController, type: :controller do
+  before do
+    @user = User.create(email: 'testenv@example.com', password: 'testpass')
+    sign_in @user
+  end
+
   describe 'GET /new ' do
     it 'responds with 200' do
       get :new
@@ -8,19 +13,15 @@ RSpec.describe PostsController, type: :controller do
     end
   end
 
-  describe "POST /" do
-    it "responds with 200" do
-      @user = User.create(:email => 'testenv@example.com', :password => 'testpass')
-      sign_in @user
-      post :create, params: { post: { message: "Hello, world!" } }
+  describe 'POST /' do
+    it 'responds with 200' do
+      post :create, params: { post: { message: 'Hello, world!' } }
       expect(response).to redirect_to("/#{@user.id}")
     end
 
-    it "creates a post" do
-      @user = User.create(:email => 'testenv@example.com', :password => 'testpass')
-      sign_in @user
+    it 'creates a post' do
       Post.create(message: 'Hello, world!', user_id: @user.id)
-      expect(Post.find_by(message: "Hello, world!")).to be
+      expect(Post.find_by(message: 'Hello, world!')).to be
     end
   end
 

--- a/spec/controllers/walls_controller_spec.rb
+++ b/spec/controllers/walls_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe WallsController, type: :controller do
-
 end

--- a/spec/features/user_can_access_appropriate_pages_spec.rb
+++ b/spec/features/user_can_access_appropriate_pages_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe 'user can access different pages when logged in or not logged in' do
+  it 'user who is not logged in tries to view a wall, and is redirected to log in' do
+    visit '/posts'
+    expect(page).to have_current_path '/'
+    expect(page).to have_button('Log in')
+  end
+end

--- a/spec/features/user_can_add_posts_to_a_wall_spec.rb
+++ b/spec/features/user_can_add_posts_to_a_wall_spec.rb
@@ -1,18 +1,18 @@
-feature 'adding posts to a wall' do
-  scenario 'posting to a persons wall and viewing it' do
-    user1 = User.create(:email => 'testenv@example.com', :password => 'testpass')
-    user2 = User.create(:email => 'testenv2@example.com', :password => 'testpass2')
-    visit "/users/sign_in"
-    fill_in "Email", with: "testenv@example.com"
-    fill_in "Password", with: "testpass"
-    click_button "Log in"
-    expect(current_path).to eq("/#{user1.id}")
+describe 'adding posts to a wall' do
+  it 'posting to a persons wall and viewing it' do
+    user1 = User.create(email: 'testenv@example.com', password: 'testpass')
+    user2 = User.create(email: 'testenv2@example.com', password: 'testpass2')
+    visit '/users/sign_in'
+    fill_in 'Email', with: 'testenv@example.com'
+    fill_in 'Password', with: 'testpass'
+    click_button 'Log in'
+    expect(page).to have_current_path("/#{user1.id}", ignore_query: true)
     visit("/#{user2.id}")
     fill_in 'post[message]', with: 'hello world'
     click_button('Post')
-    expect(current_path).to eq("/#{user2.id}")
+    expect(page).to have_current_path("/#{user2.id}", ignore_query: true)
     expect(page).to have_content('testenv2@example.com')
     expect(page).to have_content('hello world by testenv@example.com')
-    expect(current_path).to eq("/#{user2.id}")
+    expect(page).to have_current_path("/#{user2.id}", ignore_query: true)
   end
 end

--- a/spec/features/user_can_post_to_its_own_wall_spec.rb
+++ b/spec/features/user_can_post_to_its_own_wall_spec.rb
@@ -1,12 +1,12 @@
-feature 'Posting to own wall' do
-  scenario 'user can post to own wall' do
-    user = User.create(:email => 'testenv@example.com', :password => 'testpass')
-    visit "/users/sign_in"
-    fill_in "Email", with: "testenv@example.com"
-    fill_in "Password", with: "testpass"
-    click_button "Log in"
-    expect(current_path).to eq("/#{user.id}")
-    fill_in "post[message]", with: 'my wall'
+describe 'Posting to own wall' do
+  it 'user can post to own wall' do
+    user = User.create(email: 'testenv@example.com', password: 'testpass')
+    visit '/users/sign_in'
+    fill_in 'Email', with: 'testenv@example.com'
+    fill_in 'Password', with: 'testpass'
+    click_button 'Log in'
+    expect(page).to have_current_path("/#{user.id}", ignore_query: true)
+    fill_in 'post[message]', with: 'my wall'
     click_button('Post')
     expect(page).to have_content('testenv@example.com')
   end

--- a/spec/features/user_can_sign_in_spec.rb
+++ b/spec/features/user_can_sign_in_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-feature 'signing in' do
-  scenario 'user signs in with valid email and password' do
-    user = User.create(:email => 'testenv@example.com', :password => 'testpass')
+describe 'signing in' do
+  it 'user signs in with valid email and password' do
+    user = User.create(email: 'testenv@example.com', password: 'testpass')
     visit '/'
     click_button 'Log in'
     fill_in 'Email', with: 'testenv@example.com'
     fill_in 'Password', with: 'testpass'
     click_button 'Log in'
-    expect(current_path).to eq("/#{user.id}")
+    expect(page).to have_current_path("/#{user.id}", ignore_query: true)
     expect(page).to have_content 'Signed in successfully.'
   end
 

--- a/spec/features/user_can_sign_out_spec.rb
+++ b/spec/features/user_can_sign_out_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 describe 'Signing Out' do
   before do
-    @user = User.create(:email => 'testenv@example.com', :password => 'testpass')
+    @user = User.create(email: 'testenv@example.com', password: 'testpass')
   end
 
   it 'Signs out successfully' do
-    visit "/users/sign_in"
-    fill_in "Email", with: "testenv@example.com"
-    fill_in "Password", with: "testpass"
-    click_button "Log in"
+    visit '/users/sign_in'
+    fill_in 'Email', with: 'testenv@example.com'
+    fill_in 'Password', with: 'testpass'
+    click_button 'Log in'
     click_button 'Log out'
     expect(page).to have_selector(:link_or_button, 'Log in')
     expect(page).to have_current_path('/')

--- a/spec/features/user_can_sign_up_spec.rb
+++ b/spec/features/user_can_sign_up_spec.rb
@@ -6,14 +6,14 @@ describe 'Signing Up' do
     click_button 'Sign up'
     expect(page).to have_current_path('/users/sign_up')
   end
-  
-  scenario "Can sign up with valid details" do
-    visit "/users/sign_up"
-    fill_in "Email", with: "mob@example.com"
-    fill_in "Password", with: "Passwrd1"
-    fill_in "Password confirmation", with: "Passwrd1"
-    click_button "Sign up"
-    expect(page).to have_content("Welcome! You have signed up successfully.")
+
+  it 'Can sign up with valid details' do
+    visit '/users/sign_up'
+    fill_in 'Email', with: 'mob@example.com'
+    fill_in 'Password', with: 'Passwrd1'
+    fill_in 'Password confirmation', with: 'Passwrd1'
+    click_button 'Sign up'
+    expect(page).to have_content('Welcome! You have signed up successfully.')
   end
 
   it 'Signing up with a password that is too long' do


### PR DESCRIPTION
This could possibly use some more feature tests in the future, to confirm that all redirects are applying when expected.
Also noted that /posts route still exists, and is set as the root for an authenticated user.  Added a ticket to Trello about that.